### PR TITLE
Improve odometry accuracy

### DIFF
--- a/lib/Service/Odometry.cpp
+++ b/lib/Service/Odometry.cpp
@@ -58,7 +58,7 @@
  *****************************************************************************/
 
 /* Initialize static constant data. */
-const uint16_t Odometry::STEPS_THRESHOLD = static_cast<uint16_t>(RobotConstants::ENCODER_STEPS_PER_MM);
+const uint16_t Odometry::STEPS_THRESHOLD = static_cast<uint16_t>(10U * RobotConstants::ENCODER_STEPS_PER_MM);
 
 /**
  * Logging source.

--- a/lib/Service/Odometry.h
+++ b/lib/Service/Odometry.h
@@ -173,7 +173,9 @@ public:
 
 private:
     /**
-     * If at least one side moved about 2 mm, a new calculation shall be done.
+     * If at least one side moved about 1 cm, a new calculation shall be done.
+     * Don't use values lower than 1 cm, because the accuracy of the orientation
+     * will decrease massively.
      *
      * Use a multiple of RobotConstants::ENCODER_STEPS_PER_MM for better
      * accuracy.


### PR DESCRIPTION
The threshold to start the odometry calculation is set to 1 cm (10 * encoder steps per mm).

That means that the left or the right driven distance must be at least 1 cm.