### PR TITLE
Line sensors readLine() provided in simulation wrong value in case of lost track

### DIFF
--- a/lib/HALSim/LineSensors.cpp
+++ b/lib/HALSim/LineSensors.cpp
@@ -95,34 +95,52 @@ void LineSensors::calibrate()
 
 int16_t LineSensors::readLine()
 {
-    const uint32_t WEIGHT0      = 0;
-    const uint32_t WEIGHT1      = 1000;
-    const uint32_t WEIGHT2      = 2000;
-    const uint32_t WEIGHT3      = 3000;
-    const uint32_t WEIGHT4      = 4000;
+    uint8_t        idx          = 0;
     uint32_t       estimatedPos = 0;
+    uint32_t       numerator    = 0;
+    uint32_t       denominator  = 0;
+    const uint32_t WEIGHT       = 1000;
+    bool           isOnLine     = false;
 
     (void)getSensorValues();
 
+    while (MAX_SENSORS > idx)
     {
-        uint32_t numerator =    (WEIGHT0 * m_sensorValuesU16[0] +
-                                 WEIGHT1 * m_sensorValuesU16[1] +
-                                 WEIGHT2 * m_sensorValuesU16[2] +
-                                 WEIGHT3 * m_sensorValuesU16[3] +
-                                 WEIGHT4 * m_sensorValuesU16[4]);
-        uint32_t denominator = (m_sensorValuesU16[0] +
-                                m_sensorValuesU16[1] +
-                                m_sensorValuesU16[2] +
-                                m_sensorValuesU16[3] +
-                                m_sensorValuesU16[4]);
+        numerator += static_cast<uint32_t>(idx) * WEIGHT * static_cast<uint32_t>(m_sensorValuesU16[idx]);
+        denominator += static_cast<uint32_t>(m_sensorValuesU16[idx]);
 
+        /* Keep track of whether we see the line at all. */
+        if (SENSOR_OFF_LINE_THRESHOLD < m_sensorValuesU16[idx])
+        {
+            isOnLine = true;
+        }
+
+        ++idx;
+    }
+
+    if (false == isOnLine)
+    {
+        /* If it last read to the left of center, return 0. */
+        if (m_lastPosValue < (((MAX_SENSORS - 1) * SENSOR_MAX_VALUE) / 2))
+        {
+            estimatedPos = 0;
+        }
+        /* If it last read to the right of center, return the max. value. */
+        else
+        {
+            estimatedPos = (MAX_SENSORS - 1) * SENSOR_MAX_VALUE;
+        }
+    }
+    else
+    {
         /* Check to avoid division by zero. */
         if (0 == denominator)
         {
             denominator = 1;
         }
 
-        estimatedPos = numerator / denominator;
+        estimatedPos   = numerator / denominator;
+        m_lastPosValue = estimatedPos;
     }
 
     return static_cast<int16_t>(estimatedPos);

--- a/lib/HALSim/LineSensors.cpp
+++ b/lib/HALSim/LineSensors.cpp
@@ -95,7 +95,6 @@ void LineSensors::calibrate()
 
 int16_t LineSensors::readLine()
 {
-    uint8_t        idx          = 0;
     uint32_t       estimatedPos = 0;
     uint32_t       numerator    = 0;
     uint32_t       denominator  = 0;
@@ -104,18 +103,18 @@ int16_t LineSensors::readLine()
 
     (void)getSensorValues();
 
-    while (MAX_SENSORS > idx)
+    for(uint32_t idx = 0; idx < MAX_SENSORS; ++idx)
     {
-        numerator += static_cast<uint32_t>(idx) * WEIGHT * static_cast<uint32_t>(m_sensorValuesU16[idx]);
-        denominator += static_cast<uint32_t>(m_sensorValuesU16[idx]);
+        uint32_t sensorValue = m_sensorValuesU16[idx];
+
+        numerator += idx * WEIGHT * sensorValue;
+        denominator += sensorValue;
 
         /* Keep track of whether we see the line at all. */
-        if (SENSOR_OFF_LINE_THRESHOLD < m_sensorValuesU16[idx])
+        if (SENSOR_OFF_LINE_THRESHOLD < sensorValue)
         {
             isOnLine = true;
         }
-
-        ++idx;
     }
 
     if (false == isOnLine)
@@ -134,12 +133,11 @@ int16_t LineSensors::readLine()
     else
     {
         /* Check to avoid division by zero. */
-        if (0 == denominator)
+        if (0 != denominator)
         {
-            denominator = 1;
+            estimatedPos = numerator / denominator;
         }
 
-        estimatedPos   = numerator / denominator;
         m_lastPosValue = estimatedPos;
     }
 

--- a/lib/HALSim/LineSensors.h
+++ b/lib/HALSim/LineSensors.h
@@ -89,7 +89,8 @@ public:
         m_sensorCalibStarted(false),
         m_calibErrorInfo(CALIB_ERROR_NOT_CALIBRATED),
         m_sensorMinValues(),
-        m_sensorMaxValues()
+        m_sensorMaxValues(),
+        m_lastPosValue(SENSOR_MAX_VALUE * (MAX_SENSORS / 2))
     {
     }
 
@@ -194,6 +195,11 @@ private:
      */
     static const int16_t SENSOR_MAX_VALUE = 1000;
 
+    /**
+     * If above the threshold, it will be assumed that the sensor see's the line.
+     */
+    static const uint16_t SENSOR_OFF_LINE_THRESHOLD = 200;
+
     const SimTime&   m_simTime;                      /**< Simulation time */
     uint16_t         m_sensorValuesU16[MAX_SENSORS]; /**< The last value of each sensor as unsigned 16-bit values. */
     webots::Emitter* m_emitters[MAX_SENSORS];        /**< The infrared emitters (0: most left) */
@@ -203,6 +209,7 @@ private:
     uint8_t  m_calibErrorInfo; /**< Indicates which sensor failed the calibration, if the calibration failed. */
     uint16_t m_sensorMinValues[MAX_SENSORS]; /**< Stores the minimal calibration values for the sensors. */
     uint16_t m_sensorMaxValues[MAX_SENSORS]; /**< Stores the minimal calibration values for the sensors. */
+    int16_t  m_lastPosValue;                 /**< Last valid line sensor position value. */
 
     /* Default constructor not allowed. */
     LineSensors();


### PR DESCRIPTION
Line sensors readLine() behaviour fixed. Like in the Pololu original algorithm, if the sensors are not on the line, it will return the last seen position.