### PR TITLE
Bugfix: Motor calibration LineFollower

### DIFF
--- a/lib/APPLineFollower/MotorSpeedCalibrationState.cpp
+++ b/lib/APPLineFollower/MotorSpeedCalibrationState.cpp
@@ -81,6 +81,11 @@ void MotorSpeedCalibrationState::entry()
     display.gotoXY(0, 1);
     display.print("MCAL");
 
+    /* Disable differential drive control, because the max. motor speed is
+     * determined by this calibration.
+     */
+    DifferentialDrive::getInstance().disable();
+
     /* Setup relative encoders */
     m_relEncoders.clear();
 


### PR DESCRIPTION
- Fixed differential drive acting against the motor calibration
- When max. speed is greater than 0, the differential drive is enabled in StartupState. 
- This means, that the differential drive tries to keep the speed at 0, even during motor calibration.
- Solution: Disable Differential Drive during MotorCalibrationState. It is enabled again before exiting the state.