### PR TITLE
Fix Zumo density

### DIFF
--- a/webots/protos/Zumo32U4.proto
+++ b/webots/protos/Zumo32U4.proto
@@ -569,6 +569,7 @@ PROTO Zumo32U4 [
     boundingObject USE BODY
     physics Physics {
       mass 0.2
+      density -1
     }
     name IS name
     controller "<extern>"


### PR DESCRIPTION
- Density must be set to -1 when mass is defined
- Solves error: "Both 'density' and 'mass' specified: the 'density' will be ignored."
- "If the mass is known, e.g., indicated in the specifications of the robot, then it is more accurate to specify the mass rather than the density." [Source](https://cyberbotics.com/doc/reference/physics#field-summary)
- "The mass of a Solid node is given by its density or mass field. Only one of these two fields can be specified at a time (the other should be set to -1)." [Source](https://cyberbotics.com/doc/guide/tutorial-5-compound-solid-and-physics-attributes#physics-attributes)