### PR TITLE
Join DCS with RU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lib/Webots
 webots/worlds/*.jpg
 doc/doxygen/*/*
 __pycache__
+tmp/

--- a/webots/protos/Zumo32U4.proto
+++ b/webots/protos/Zumo32U4.proto
@@ -3,10 +3,11 @@
 EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023a/projects/appearances/protos/Rubber.proto"
 
 PROTO Zumo32U4 [
-  field SFVec3f     translation     0 0 0
-  field SFRotation  rotation        0 0 1 0
-  field SFString    name            "Zumo"
-  field SFString    contactMaterial "default" # Contact material of the tracks
+  field SFVec3f     translation       0 0 0
+  field SFRotation  rotation          0 0 1 0
+  field SFString    name              "Zumo"
+  field SFString    contactMaterial   "default" # Contact material of the tracks
+  field SFNode      zumoComSystemSlot NULL      # Slot for the ZumoComSystem
 ]
 {
   Robot {
@@ -22,6 +23,10 @@ PROTO Zumo32U4 [
         type "serial"
       }
       Speaker {
+      }
+      Slot {
+        type "ZumoComSystem"
+        endPoint IS zumoComSystemSlot
       }
       DEF SHIELD Group {
         children [
@@ -42,7 +47,6 @@ PROTO Zumo32U4 [
         ]
       }
       DEF TRACK_LEFT Track {
-        contactMaterial IS contactMaterial
         translation 0 0.0375 0
         rotation 0 1 0 0
         children [
@@ -77,6 +81,7 @@ PROTO Zumo32U4 [
           }
         ]
         name "left_track"
+        contactMaterial IS contactMaterial
         boundingObject DEF TRACK_BO Group {
           children [
             Transform {
@@ -128,7 +133,6 @@ PROTO Zumo32U4 [
         geometriesCount 70
       }
       DEF TRACK_RIGHT Track {
-        contactMaterial IS contactMaterial
         translation 0 -0.0375 0
         children [
           DEF WHEEL_FR TrackWheel {
@@ -162,6 +166,7 @@ PROTO Zumo32U4 [
           }
         ]
         name "track_right"
+        contactMaterial IS contactMaterial
         boundingObject USE TRACK_BO
         physics USE TRACK_PH
         device [
@@ -435,8 +440,8 @@ PROTO Zumo32U4 [
               0.301 0 0
             ]
             type "infra-red"
-            aperture 0.4
             numberOfRays 5
+            aperture 0.4
             gaussianWidth 1000
           }
           DistanceSensor {
@@ -460,47 +465,36 @@ PROTO Zumo32U4 [
           }
         ]
       }
-    DEF IMU Group {
+      DEF IMU Group {
         children [
           Accelerometer {
-            name "accelerometer"
-            xAxis TRUE
-            yAxis TRUE
-            zAxis TRUE
-            resolution  0.001
             lookupTable [
               -19.62 -32768 0.001
-              0 0  0.001
+              0 0 0.001
               19.62 32767 0.001
             ]
+            resolution 0.001
           }
           Gyro {
             name "gyro"
-            xAxis TRUE
-            yAxis TRUE
-            zAxis TRUE
-            resolution  0.001
             lookupTable [
               -9.32 -32768 0
               0 0 0
               9.32 32767 0
             ]
+            resolution 0.001
           }
           Compass {
             name "magnetometer"
-            xAxis TRUE
-            yAxis TRUE
-            zAxis TRUE
-            resolution  0.001
             lookupTable [
               -1 -32000 0
               0 0 0
               1 32000 0
             ]
+            resolution 0.001
           }
         ]
       }
-
       DEF LEDS Group {
         children [
           LED {
@@ -576,12 +570,12 @@ PROTO Zumo32U4 [
         ]
       }
     ]
+    name IS name
     boundingObject USE BODY
     physics Physics {
-      mass 0.2
       density -1
+      mass 0.2
     }
-    name IS name
     controller "<extern>"
   }
 }

--- a/webots/protos/ZumoComSystem.proto
+++ b/webots/protos/ZumoComSystem.proto
@@ -1,43 +1,43 @@
 #VRML_SIM R2023a utf8
 
 PROTO ZumoComSystem [
-  field SFVec3f     translation 0 0 0
-  field SFRotation  rotation    0 0 1 0
-  field SFString    name        "ZumoComSystem"
+  field SFString name "ZumoComSystem"
 ]
 {
-  Robot {
-    translation IS translation
-    rotation IS rotation
-    children [
-      DEF BODY Group {
-        children [
-          Shape {
-            geometry Box {
-              size 0.06 0.05 0.01
+  Slot {
+    type "ZumoComSystem"
+    endPoint Robot {
+      translation 0 0 0.1
+      children [
+        DEF BODY Group {
+          children [
+            Shape {
+              geometry Box {
+                size 0.06 0.05 0.01
+              }
             }
-          }
-        ]
+          ]
+        }
+        Receiver {
+          name "serialComRx"
+          type "serial"
+        }
+        Emitter {
+          name "serialComTx"
+          type "serial"
+        }
+        GPS {
+          name "gps"
+        }
+      ]
+      name IS name
+      description "DroidControlShip"
+      boundingObject USE BODY
+      physics Physics {
+        density -1
+        mass 0.1
       }
-      Receiver {
-        name "serialComRx"
-        type "serial"
-      }
-      Emitter {
-        name "serialComTx"
-        type "serial"
-      }
-      GPS {
-        name "gps"
-      }
-    ]
-    name IS name
-    description "DroidControlShip"
-    boundingObject USE BODY
-    physics Physics {
-      density -1
-      mass 0.1
+      controller "<extern>"
     }
-    controller "<extern>"
   }
 }

--- a/webots/worlds/zumo_with_com_system/LineFollowerTrack.wbt
+++ b/webots/worlds/zumo_with_com_system/LineFollowerTrack.wbt
@@ -39,11 +39,9 @@ DEF ROBOT Zumo32U4 {
   rotation -1.0564747468923541e-06 8.746699709178704e-07 0.9999999999990595 1.5880805820884731
   name "Zumo"
   contactMaterial "rubber"
-}
-ZumoComSystem {
-  translation 0 0 0
-  rotation 0 0 1 0
-  name "ZumoComSystem"
+  zumoComSystemSlot ZumoComSystem {
+    name "ZumoComSystem"
+  }
 }
 Supervisor {
   name "Supervisor"

--- a/webots/worlds/zumo_with_com_system/PlatoonTrack.wbt
+++ b/webots/worlds/zumo_with_com_system/PlatoonTrack.wbt
@@ -41,33 +41,27 @@ DEF LEADER Zumo32U4 {
   rotation -1.0564747468923541e-06 8.746699709178704e-07 0.9999999999990595 1.5880805820884731
   name "leader"
   contactMaterial "rubber"
-}
-ZumoComSystem {
-  translation 0 0 0
-  rotation 0 0 1 0
-  name "ZumoComSystemLeader"
+  zumoComSystemSlot ZumoComSystem {
+    name "ZumoComSystemLeader"
+  }
 }
 DEF FOLLOWER1 Zumo32U4 {
   translation -3.15 -1.2 0.013994298332013683
   rotation -1.0564747468923541e-06 8.746699709178704e-07 0.9999999999990595 1.5880805820884731
   name "follower_1"
   contactMaterial "rubber"
-}
-ZumoComSystem {
-  translation 0 0 0
-  rotation 0 0 1 0
-  name "ZumoComSystemFollower1"
+  zumoComSystemSlot ZumoComSystem {
+    name "ZumoComSystemFollower1"
+  }
 }
 DEF FOLLOWER2 Zumo32U4 {
   translation -3.15 -1.35 0.013994298332013683
   rotation -1.0564747468923541e-06 8.746699709178704e-07 0.9999999999990595 1.5880805820884731
   name "follower_2"
   contactMaterial "rubber"
-}
-ZumoComSystem {
-  translation 0 0 0
-  rotation 0 0 1 0
-  name "ZumoComSystemFollower2"
+  zumoComSystemSlot ZumoComSystem {
+    name "ZumoComSystemFollower2"
+  }
 }
 Supervisor {
   name "PlatoonSupervisor"

--- a/webots/worlds/zumo_with_com_system/SensorFusionTrack.wbt
+++ b/webots/worlds/zumo_with_com_system/SensorFusionTrack.wbt
@@ -39,11 +39,9 @@ DEF ROBOT Zumo32U4 {
   rotation -1.0564747468923541e-06 8.746699709178704e-07 0.9999999999990595 1.5880805820884731
   name "Zumo"
   contactMaterial "rubber"
-}
-ZumoComSystem {
-  translation 0 0 0
-  rotation 0 0 1 0
-  name "ZumoComSystem"
+  zumoComSystemSlot ZumoComSystem {
+    name "ZumoComSystem"
+  }
 }
 Supervisor {
   name "Supervisor"


### PR DESCRIPTION
- Uses `Slot` to append the DCS to the RU
- Can be left empty if DCS is not being used.
- Fixed alignment and order of some lines in the `wbt` files. Uses the format and order that Webots uses when saving the file.
- In IMU  group: Removed properties that have the default value