### PR TITLE
Turtle functionality in RemoteControl

### DIFF
--- a/lib/APPRemoteControl/src/App.cpp
+++ b/lib/APPRemoteControl/src/App.cpp
@@ -364,7 +364,7 @@ void App_motorSpeedSetpointsChannelCallback(const uint8_t* payload, const uint8_
     if ((nullptr != payload) && (MOTOR_SPEED_SETPOINT_CHANNEL_DLC == payloadSize))
     {
         const MotorSpeed* motorSpeedData = reinterpret_cast<const MotorSpeed*>(payload);
-        DrivingState::getInstance().setTargetSpeeds(motorSpeedData->left, motorSpeedData->right);
+        DrivingState::getInstance().setMotorSpeeds(motorSpeedData->left, motorSpeedData->right);
     }
 }
 
@@ -404,10 +404,7 @@ void App_turtleChannelCallback(const uint8_t* payload, const uint8_t payloadSize
         /* Convert to [steps/s] */
         int16_t centerSpeed = Util::millimetersPerSecondToStepsPerSecond(turtleSpeedData->linearCenter);
 
-        /* Linear speed is set first. Overwrites all speed setpoints. */
-        diffDrive.setLinearSpeed(centerSpeed);
-
-        /* Angular speed is set on-top of the linear speed. Must be called after setLinearSpeed(). */
-        diffDrive.setAngularSpeed(angularSpeed);
+        /* Set the robot speeds. */
+        DrivingState::getInstance().setRobotSpeeds(centerSpeed, angularSpeed);
     }
 }

--- a/lib/APPRemoteControl/src/App.cpp
+++ b/lib/APPRemoteControl/src/App.cpp
@@ -284,9 +284,9 @@ bool App::setupSerialMuxProt()
 
     /* Channel subscription. */
     m_smpServer.subscribeToChannel(COMMAND_CHANNEL_NAME, App_cmdChannelCallback);
-    m_smpServer.subscribeToChannel(SPEED_SETPOINT_CHANNEL_NAME, App_motorSpeedSetpointsChannelCallback);
+    m_smpServer.subscribeToChannel(MOTOR_SPEED_SETPOINT_CHANNEL_NAME, App_motorSpeedSetpointsChannelCallback);
     m_smpServer.subscribeToChannel(STATUS_CHANNEL_NAME, App_statusChannelCallback);
-    m_smpServer.subscribeToChannel(TURTLE_CHANNEL_NAME, App_turtleChannelCallback);
+    m_smpServer.subscribeToChannel(ROBOT_SPEED_SETPOINT_CHANNEL_NAME, App_turtleChannelCallback);
 
     /* Channel creation. */
     m_serialMuxProtChannelIdRemoteCtrlRsp =
@@ -361,9 +361,9 @@ static void App_cmdChannelCallback(const uint8_t* payload, const uint8_t payload
 void App_motorSpeedSetpointsChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
 {
     (void)userData;
-    if ((nullptr != payload) && (SPEED_SETPOINT_CHANNEL_DLC == payloadSize))
+    if ((nullptr != payload) && (MOTOR_SPEED_SETPOINT_CHANNEL_DLC == payloadSize))
     {
-        const SpeedData* motorSpeedData = reinterpret_cast<const SpeedData*>(payload);
+        const MotorSpeed* motorSpeedData = reinterpret_cast<const MotorSpeed*>(payload);
         DrivingState::getInstance().setTargetSpeeds(motorSpeedData->left, motorSpeedData->right);
     }
 }
@@ -388,16 +388,16 @@ void App_statusChannelCallback(const uint8_t* payload, const uint8_t payloadSize
 /**
  * Receives Turtle speed setpoints over SerialMuxProt channel.
  *
- * @param[in] payload       Linear and angular speed setpoints in a TurtleSpeed structure.
- * @param[in] payloadSize   Size of the TurtleSpeed structure.
+ * @param[in] payload       Linear and angular speed setpoints in a RobotSpeed structure.
+ * @param[in] payloadSize   Size of the RobotSpeed structure.
  * @param[in] userData      Instance of App class.
  */
 void App_turtleChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
 {
     (void)userData;
-    if ((nullptr != payload) && (TURTLE_CHANNEL_DLC == payloadSize))
+    if ((nullptr != payload) && (ROBOT_SPEED_SETPOINT_CHANNEL_DLC == payloadSize))
     {
-        const TurtleSpeed* turtleSpeedData = reinterpret_cast<const TurtleSpeed*>(payload);
+        const RobotSpeed*  turtleSpeedData = reinterpret_cast<const RobotSpeed*>(payload);
         DifferentialDrive& diffDrive       = DifferentialDrive::getInstance();
         int16_t            angularSpeed    = static_cast<int16_t>(turtleSpeedData->angular);
 

--- a/lib/APPRemoteControl/src/App.cpp
+++ b/lib/APPRemoteControl/src/App.cpp
@@ -63,7 +63,7 @@
 static void App_cmdChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData);
 static void App_motorSpeedSetpointsChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData);
 static void App_statusChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData);
-static void App_turtleChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData);
+static void App_robotSpeedSetpointChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData);
 
 /******************************************************************************
  * Local Variables
@@ -286,7 +286,7 @@ bool App::setupSerialMuxProt()
     m_smpServer.subscribeToChannel(COMMAND_CHANNEL_NAME, App_cmdChannelCallback);
     m_smpServer.subscribeToChannel(MOTOR_SPEED_SETPOINT_CHANNEL_NAME, App_motorSpeedSetpointsChannelCallback);
     m_smpServer.subscribeToChannel(STATUS_CHANNEL_NAME, App_statusChannelCallback);
-    m_smpServer.subscribeToChannel(ROBOT_SPEED_SETPOINT_CHANNEL_NAME, App_turtleChannelCallback);
+    m_smpServer.subscribeToChannel(ROBOT_SPEED_SETPOINT_CHANNEL_NAME, App_robotSpeedSetpointChannelCallback);
 
     /* Channel creation. */
     m_serialMuxProtChannelIdRemoteCtrlRsp =
@@ -386,23 +386,22 @@ void App_statusChannelCallback(const uint8_t* payload, const uint8_t payloadSize
 }
 
 /**
- * Receives Turtle speed setpoints over SerialMuxProt channel.
+ * Receives robot speed setpoints over SerialMuxProt channel.
  *
  * @param[in] payload       Linear and angular speed setpoints in a RobotSpeed structure.
  * @param[in] payloadSize   Size of the RobotSpeed structure.
  * @param[in] userData      Instance of App class.
  */
-void App_turtleChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
+void App_robotSpeedSetpointChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
 {
     (void)userData;
     if ((nullptr != payload) && (ROBOT_SPEED_SETPOINT_CHANNEL_DLC == payloadSize))
     {
-        const RobotSpeed*  turtleSpeedData = reinterpret_cast<const RobotSpeed*>(payload);
-        DifferentialDrive& diffDrive       = DifferentialDrive::getInstance();
-        int16_t            angularSpeed    = static_cast<int16_t>(turtleSpeedData->angular);
+        const RobotSpeed* robotSpeedData = reinterpret_cast<const RobotSpeed*>(payload);
+        int16_t           angularSpeed   = static_cast<int16_t>(robotSpeedData->angular);
 
         /* Convert to [steps/s] */
-        int16_t centerSpeed = Util::millimetersPerSecondToStepsPerSecond(turtleSpeedData->linearCenter);
+        int16_t centerSpeed = Util::millimetersPerSecondToStepsPerSecond(robotSpeedData->linearCenter);
 
         /* Set the robot speeds. */
         DrivingState::getInstance().setRobotSpeeds(centerSpeed, angularSpeed);

--- a/lib/APPRemoteControl/src/App.cpp
+++ b/lib/APPRemoteControl/src/App.cpp
@@ -200,8 +200,6 @@ void App::handleRemoteCommand(const Command& cmd)
         Odometry::getInstance().clearMileage();
         Odometry::getInstance().setPosition(cmd.xPos, cmd.yPos);
         Odometry::getInstance().setOrientation(cmd.orientation);
-
-        StartupState::getInstance().notifyInitialDataIsSet();
         break;
 
     default:
@@ -411,8 +409,5 @@ void App_turtleChannelCallback(const uint8_t* payload, const uint8_t payloadSize
 
         /* Angular speed is set on-top of the linear speed. Must be called after setLinearSpeed(). */
         diffDrive.setAngularSpeed(angularSpeed);
-
-        /* Turtle expects no initial data. Can be called without side-effects when no longer in StartupState. */
-        StartupState::getInstance().notifyInitialDataIsSet();
     }
 }

--- a/lib/APPRemoteControl/src/App.cpp
+++ b/lib/APPRemoteControl/src/App.cpp
@@ -363,8 +363,10 @@ void App_motorSpeedSetpointsChannelCallback(const uint8_t* payload, const uint8_
     (void)userData;
     if ((nullptr != payload) && (MOTOR_SPEED_SETPOINT_CHANNEL_DLC == payloadSize))
     {
-        const MotorSpeed* motorSpeedData = reinterpret_cast<const MotorSpeed*>(payload);
-        DrivingState::getInstance().setMotorSpeeds(motorSpeedData->left, motorSpeedData->right);
+        const MotorSpeed* motorSpeedData  = reinterpret_cast<const MotorSpeed*>(payload);
+        int16_t           leftMotorSpeed  = Util::millimetersPerSecondToStepsPerSecond(motorSpeedData->left);
+        int16_t           rightMotorSpeed = Util::millimetersPerSecondToStepsPerSecond(motorSpeedData->right);
+        DrivingState::getInstance().setMotorSpeeds(leftMotorSpeed, rightMotorSpeed);
     }
 }
 

--- a/lib/APPRemoteControl/src/DrivingState.cpp
+++ b/lib/APPRemoteControl/src/DrivingState.cpp
@@ -84,11 +84,25 @@ void DrivingState::exit()
     DifferentialDrive::getInstance().disable();
 }
 
-void DrivingState::setTargetSpeeds(int16_t leftMotor, int16_t rightMotor)
+void DrivingState::setMotorSpeeds(int16_t leftMotor, int16_t rightMotor)
 {
     if (true == m_isActive)
     {
         DifferentialDrive::getInstance().setLinearSpeed(leftMotor, rightMotor);
+    }
+}
+
+void DrivingState::setRobotSpeeds(int16_t linearSpeed, int16_t angularSpeed)
+{
+    if (true == m_isActive)
+    {
+        DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
+
+        /* Linear speed is set first. Overwrites all speed setpoints. */
+        diffDrive.setLinearSpeed(linearSpeed);
+
+        /* Angular speed is set on-top of the linear speed. Must be called after setLinearSpeed(). */
+        diffDrive.setAngularSpeed(angularSpeed);
     }
 }
 

--- a/lib/APPRemoteControl/src/DrivingState.h
+++ b/lib/APPRemoteControl/src/DrivingState.h
@@ -91,12 +91,20 @@ public:
     void exit() final;
 
     /**
-     * Set target motor speeds.
+     * Set the motor speeds.
      *
      * @param[in] leftMotor  Left motor speed. [steps/s]
      * @param[in] rightMotor Right motor speed. [steps/s]
      */
-    void setTargetSpeeds(int16_t leftMotor, int16_t rightMotor);
+    void setMotorSpeeds(int16_t leftMotor, int16_t rightMotor);
+
+    /**
+     * Set the robot speeds.
+     *
+     * @param[in] linearSpeed   Linear speed in [steps/s]
+     * @param[in] angularSpeed  Angular speed in [mrad/s]
+     */
+    void setRobotSpeeds(int16_t linearSpeed, int16_t angularSpeed);
 
 protected:
 private:

--- a/lib/APPRemoteControl/src/SerialMuxChannels.h
+++ b/lib/APPRemoteControl/src/SerialMuxChannels.h
@@ -82,6 +82,12 @@
 /** DLC of Line Sensor Channel */
 #define LINE_SENSOR_CHANNEL_DLC (sizeof(LineSensorData))
 
+/** Name of the Channel to send Turtle Speeds. */
+#define TURTLE_CHANNEL_NAME "TURTLE"
+
+/** DLC of Turtle Channel */
+#define TURTLE_CHANNEL_DLC (sizeof(TurtleSpeed))
+
 /******************************************************************************
  * Types and Classes
  *****************************************************************************/
@@ -204,6 +210,13 @@ typedef struct _LineSensorData
 {
     uint16_t lineSensorData[5U]; /**< Line sensor data [digits] normalized to max 1000 digits. */
 } __attribute__((packed)) LineSensorData;
+
+/** Struct of the "Turtle" channel payload. */
+typedef struct _TurtleSpeed
+{
+    int32_t linearCenter; /**< Linear speed of the vehicle center. [mm/s] */
+    int32_t angular;      /**< Angular speed. [mrad/s] */
+} __attribute__((packed)) TurtleSpeed;
 
 /******************************************************************************
  * Functions

--- a/lib/APPRemoteControl/src/SerialMuxChannels.h
+++ b/lib/APPRemoteControl/src/SerialMuxChannels.h
@@ -59,10 +59,16 @@
 #define COMMAND_RESPONSE_CHANNEL_DLC (sizeof(CommandResponse))
 
 /** Name of Channel to send Motor Speed Setpoints to. */
-#define SPEED_SETPOINT_CHANNEL_NAME "SPEED_SET"
+#define MOTOR_SPEED_SETPOINT_CHANNEL_NAME "MOTOR_SET"
 
-/** DLC of Speedometer Channel */
-#define SPEED_SETPOINT_CHANNEL_DLC (sizeof(SpeedData))
+/** DLC of Motor Speed Setpoint Channel */
+#define MOTOR_SPEED_SETPOINT_CHANNEL_DLC (sizeof(MotorSpeed))
+
+/** Name of the Channel to send Robot Speed Setpoints to. */
+#define ROBOT_SPEED_SETPOINT_CHANNEL_NAME "ROBOT_SET"
+
+/** DLC of Robot Speed Setpoint Channel */
+#define ROBOT_SPEED_SETPOINT_CHANNEL_DLC (sizeof(RobotSpeed))
 
 /** Name of Channel to send Current Vehicle Data to. */
 #define CURRENT_VEHICLE_DATA_CHANNEL_NAME "CURR_DATA"
@@ -81,12 +87,6 @@
 
 /** DLC of Line Sensor Channel */
 #define LINE_SENSOR_CHANNEL_DLC (sizeof(LineSensorData))
-
-/** Name of the Channel to send Turtle Speeds. */
-#define TURTLE_CHANNEL_NAME "TURTLE"
-
-/** DLC of Turtle Channel */
-#define TURTLE_CHANNEL_DLC (sizeof(TurtleSpeed))
 
 /******************************************************************************
  * Types and Classes
@@ -179,13 +179,19 @@ typedef struct _CommandResponse
     };
 } __attribute__((packed)) CommandResponse;
 
-/** Struct of the "Speed" channel payload. */
-typedef struct _SpeedData
+/** Struct of the "Motor Speed Setpoints" channel payload. */
+typedef struct _MotorSpeed
 {
-    int32_t left;   /**< Left motor speed [mm/s] */
-    int32_t right;  /**< Right motor speed [mm/s] */
-    int32_t center; /**< Center motor speed [mm/s] */
-} __attribute__((packed)) SpeedData;
+    int32_t left;  /**< Left motor speed [mm/s] */
+    int32_t right; /**< Right motor speed [mm/s] */
+} __attribute__((packed)) MotorSpeed;
+
+/** Struct of the "Robot Speed Setpoints" channel payload. */
+typedef struct _RobotSpeed
+{
+    int32_t linearCenter; /**< Linear speed of the vehicle center. [mm/s] */
+    int32_t angular;      /**< Angular speed. [mrad/s] */
+} __attribute__((packed)) RobotSpeed;
 
 /** Struct of the "Current Vehicle Data" channel payload. */
 typedef struct _VehicleData
@@ -210,13 +216,6 @@ typedef struct _LineSensorData
 {
     uint16_t lineSensorData[5U]; /**< Line sensor data [digits] normalized to max 1000 digits. */
 } __attribute__((packed)) LineSensorData;
-
-/** Struct of the "Turtle" channel payload. */
-typedef struct _TurtleSpeed
-{
-    int32_t linearCenter; /**< Linear speed of the vehicle center. [mm/s] */
-    int32_t angular;      /**< Angular speed. [mrad/s] */
-} __attribute__((packed)) TurtleSpeed;
 
 /******************************************************************************
  * Functions

--- a/lib/APPRemoteControl/src/StartupState.cpp
+++ b/lib/APPRemoteControl/src/StartupState.cpp
@@ -96,7 +96,7 @@ void StartupState::process(StateMachine& sm)
         ErrorState::getInstance().setErrorMsg("MCAL=0");
         sm.setState(&ErrorState::getInstance());
     }
-    else if (true == m_initialDataSet)
+    else
     {
         sm.setState(&DrivingState::getInstance());
     }

--- a/lib/APPRemoteControl/src/StartupState.h
+++ b/lib/APPRemoteControl/src/StartupState.h
@@ -89,14 +89,6 @@ public:
      */
     void exit() final;
 
-    /**
-     * Notify the state, that the initial data set was received.
-     */
-    void notifyInitialDataIsSet()
-    {
-        m_initialDataSet = true;
-    }
-
 protected:
 private:
     /**
@@ -105,14 +97,9 @@ private:
     static const uint32_t APP_NAME_DURATION = 2000U;
 
     /**
-     * Flag to indicate, that the initial data was set.
-     */
-    bool m_initialDataSet;
-
-    /**
      * Default constructor.
      */
-    StartupState() : m_initialDataSet(false)
+    StartupState()
     {
     }
 

--- a/lib/MainNative/src/main.cpp
+++ b/lib/MainNative/src/main.cpp
@@ -58,6 +58,7 @@ typedef struct
     bool        isZumoComSystemEnabled; /**< Is the ZumoComSystem enabled? */
     const char* serialRxChannel;        /**< Serial Rx channel */
     const char* serialTxChannel;        /**< Serial Tx channel */
+    const char* cwd;                    /**< Current working directory */
 
 } PrgArguments;
 
@@ -78,7 +79,7 @@ static void          systemDelay(unsigned long ms);
 static const struct option LONG_OPTIONS[] = {{"help", no_argument, nullptr, 0},
                                              {"serialRxCh", required_argument, nullptr, 0},
                                              {"serialTxCh", required_argument, nullptr, 0},
-                                             {"cwd",        required_argument, nullptr, 0},
+                                             {"cwd", required_argument, nullptr, 0},
                                              {nullptr, no_argument, nullptr, 0}}; /* Marks the end. */
 
 /** Program argument default value of the robot name. */
@@ -95,6 +96,9 @@ static const char PRG_ARG_SERIAL_RX_CH_DEFAULT[] = "1";
 
 /** Program argument default value of the serial tx channel. */
 static const char PRG_ARG_SERIAL_TX_CH_DEFAULT[] = "2";
+
+/** Program argument default value of the current working directory. */
+static const char* PRG_ARG_CWD_DEFAULT = ".";
 
 /**
  * The maximum duration a simulated time step can have.
@@ -142,6 +146,16 @@ extern int main(int argc, char** argv)
         if (true == prgArguments.verbose)
         {
             showPrgArguments(prgArguments);
+        }
+
+        /* Set the current working directory. */
+        if (0 != strcmp(PRG_ARG_CWD_DEFAULT, prgArguments.cwd))
+        {
+            if (0 != chdir(prgArguments.cwd))
+            {
+                printf("Failed to set current working directory: %s\n", prgArguments.cwd);
+                status = -1;
+            }
         }
 
         /* It might happen that the user enables the ZumoComSystem, but the
@@ -246,6 +260,7 @@ static int handleCommandLineArguments(PrgArguments& prgArguments, int argc, char
     prgArguments.isZumoComSystemEnabled = PRG_ARG_IS_ZUMO_COM_SYSTEM_ENABLED_DEFAULT;
     prgArguments.serialRxChannel        = PRG_ARG_SERIAL_RX_CH_DEFAULT;
     prgArguments.serialTxChannel        = PRG_ARG_SERIAL_TX_CH_DEFAULT;
+    prgArguments.cwd                    = PRG_ARG_CWD_DEFAULT;
 
     while ((-1 != option) && (0 == status))
     {
@@ -267,7 +282,7 @@ static int handleCommandLineArguments(PrgArguments& prgArguments, int argc, char
             }
             else if (0 == strcmp(LONG_OPTIONS[optionIndex].name, "cwd"))
             {
-                chdir(optarg);
+                prgArguments.cwd = optarg;
             }
             else
             {
@@ -330,6 +345,7 @@ static void showPrgArguments(const PrgArguments& prgArgs)
     printf("ZumoComSystem    : %s\n", (false == prgArgs.isZumoComSystemEnabled) ? "disabled" : "enabled");
     printf("Serial rx channel: %s\n", prgArgs.serialRxChannel);
     printf("Serial tx channel: %s\n", prgArgs.serialTxChannel);
+    printf("Current working directory: %s\n", prgArgs.cwd);
     /* Skip verbose flag. */
 }
 

--- a/lib/Service/src/DifferentialDrive.cpp
+++ b/lib/Service/src/DifferentialDrive.cpp
@@ -245,9 +245,10 @@ DifferentialDrive::DifferentialDrive() :
 void DifferentialDrive::calculateLinearSpeedLeftRight(int16_t linearSpeedCenter, int16_t angularSpeed,
                                                       int16_t& linearSpeedLeft, int16_t& linearSpeedRight)
 {
-    int32_t linearSpeedCenter32 = static_cast<int32_t>(linearSpeedCenter);          /* [steps/s] */
-    int32_t angularSpeed32      = static_cast<int32_t>(angularSpeed);               /* [mrad/s] */
-    int32_t wheelBase32         = static_cast<int32_t>(RobotConstants::WHEEL_BASE); /* [mm] */
+    int32_t linearSpeedCenter32 = static_cast<int32_t>(linearSpeedCenter);                   /* [steps/s] */
+    int32_t angularSpeed32      = static_cast<int32_t>(angularSpeed);                        /* [mrad/s] */
+    int32_t wheelBase32         = static_cast<int32_t>(RobotConstants::WHEEL_BASE);          /* [mm] */
+    int32_t encoderSteps32      = static_cast<int32_t>(RobotConstants::ENCODER_STEPS_PER_M); /* [steps/m] */
 
     /* angular speed = 2 * (linear speed right - linear speed left ) / wheel base
      * linear speed right - linear speed left = angular speed * wheel base / 2
@@ -255,8 +256,8 @@ void DifferentialDrive::calculateLinearSpeedLeftRight(int16_t linearSpeedCenter,
      * linear speed right = - linear speed left
      */
 
-    linearSpeedLeft  = linearSpeedCenter32 - (angularSpeed32 * wheelBase32) / 2;
-    linearSpeedRight = linearSpeedCenter32 + (angularSpeed32 * wheelBase32) / 2;
+    linearSpeedLeft  = (linearSpeedCenter32 / 2) - ((angularSpeed32 / 1000) * (wheelBase32) * (encoderSteps32 / 1000));
+    linearSpeedRight = (linearSpeedCenter32 / 2) + ((angularSpeed32 / 1000) * (wheelBase32) * (encoderSteps32 / 1000));
 }
 
 void DifferentialDrive::calculateLinearAndAngularSpeedCenter(int16_t linearSpeedLeft, int16_t linearSpeedRight,

--- a/lib/Service/src/DifferentialDrive.cpp
+++ b/lib/Service/src/DifferentialDrive.cpp
@@ -245,10 +245,9 @@ DifferentialDrive::DifferentialDrive() :
 void DifferentialDrive::calculateLinearSpeedLeftRight(int16_t linearSpeedCenter, int16_t angularSpeed,
                                                       int16_t& linearSpeedLeft, int16_t& linearSpeedRight)
 {
-    int32_t linearSpeedCenter32 = static_cast<int32_t>(linearSpeedCenter);                   /* [steps/s] */
-    int32_t angularSpeed32      = static_cast<int32_t>(angularSpeed);                        /* [mrad/s] */
-    int32_t wheelBase32         = static_cast<int32_t>(RobotConstants::WHEEL_BASE);          /* [mm] */
-    int32_t encoderSteps32      = static_cast<int32_t>(RobotConstants::ENCODER_STEPS_PER_M); /* [steps/m] */
+    int32_t linearSpeedCenter32 = static_cast<int32_t>(linearSpeedCenter);          /* [steps/s] */
+    int32_t angularSpeed32      = static_cast<int32_t>(angularSpeed);               /* [mrad/s] */
+    int32_t wheelBase32         = static_cast<int32_t>(RobotConstants::WHEEL_BASE); /* [mm] */
 
     /* angular speed = 2 * (linear speed right - linear speed left ) / wheel base
      * linear speed right - linear speed left = angular speed * wheel base / 2
@@ -256,8 +255,8 @@ void DifferentialDrive::calculateLinearSpeedLeftRight(int16_t linearSpeedCenter,
      * linear speed right = - linear speed left
      */
 
-    linearSpeedLeft  = (linearSpeedCenter32 / 2) - ((angularSpeed32 / 1000) * (wheelBase32) * (encoderSteps32 / 1000));
-    linearSpeedRight = (linearSpeedCenter32 / 2) + ((angularSpeed32 / 1000) * (wheelBase32) * (encoderSteps32 / 1000));
+    linearSpeedLeft  = linearSpeedCenter32 - (angularSpeed32 * wheelBase32) / 2;
+    linearSpeedRight = linearSpeedCenter32 + (angularSpeed32 * wheelBase32) / 2;
 }
 
 void DifferentialDrive::calculateLinearAndAngularSpeedCenter(int16_t linearSpeedLeft, int16_t linearSpeedRight,


### PR DESCRIPTION
Added SerialMuxProt channel for turtle application. Makes calls to DifferentialDrive to update the linear and angular speeds.



This PR is a draft as it has not been completely tested