### PR TITLE
Fix #152 Wrong motor reset on direction change.

### DIFF
--- a/lib/Service/src/Speedometer.cpp
+++ b/lib/Service/src/Speedometer.cpp
@@ -98,7 +98,7 @@ void Speedometer::process()
 
         if (currentDrivingDirection != m_lastDirectionRight)
         {
-            resetLeft = true;
+            resetRight = true;
         }
 
         m_lastDirectionRight = currentDrivingDirection;


### PR DESCRIPTION
The speedometer wrongly reseted the speed of the
left motor when it detects a direction change of the "right" one.