### PR TITLE
MovAvg sum type

### DIFF
--- a/doc/architecture/uml/LogicalView/Service.plantuml
+++ b/doc/architecture/uml/LogicalView/Service.plantuml
@@ -36,7 +36,7 @@ package "Service" as serviceLayer {
         on the track.
     end note
 
-    class MovAvg < T, length > <<service>>
+    class MovAvg < T, U, length > <<service>>
 
     note top of MovAvg
         Moving average filter which can be

--- a/lib/APPConvoyFollower/src/App.h
+++ b/lib/APPConvoyFollower/src/App.h
@@ -171,7 +171,7 @@ private:
     /**
      * Moving average filter for proximity sensors.
      */
-    MovAvg<uint8_t, MOVAVG_PROXIMITY_SENSOR_NUM_MEASUREMENTS> m_movAvgProximitySensor;
+    MovAvg<uint8_t, uint16_t, MOVAVG_PROXIMITY_SENSOR_NUM_MEASUREMENTS> m_movAvgProximitySensor;
 
     /**
      * Report the current vehicle data.

--- a/lib/APPConvoyLeader/src/App.h
+++ b/lib/APPConvoyLeader/src/App.h
@@ -172,7 +172,7 @@ private:
     /**
      * Moving average filter for proximity sensors.
      */
-    MovAvg<uint8_t, MOVAVG_PROXIMITY_SENSOR_NUM_MEASUREMENTS> m_movAvgProximitySensor;
+    MovAvg<uint8_t, uint16_t, MOVAVG_PROXIMITY_SENSOR_NUM_MEASUREMENTS> m_movAvgProximitySensor;
 
     /**
      * Report the current vehicle data.

--- a/lib/APPConvoyLeader/src/DrivingState.h
+++ b/lib/APPConvoyLeader/src/DrivingState.h
@@ -141,7 +141,7 @@ private:
     LineStatus             m_lineStatus;  /**< Status of start-/end line detection */
     TrackStatus            m_trackStatus; /**< Status of track which means on track or track lost, etc. */
     uint8_t m_startEndLineDebounce;       /**< Counter used for easys debouncing of the start-/end line detection. */
-    MovAvg<int16_t, 2> m_posMovAvg;       /**< The moving average of the position over 2 calling cycles. */
+    MovAvg<int16_t, uint32_t, 2> m_posMovAvg; /**< The moving average of the position over 2 calling cycles. */
 
     /**
      * Default constructor.

--- a/lib/APPConvoyLeader/src/DrivingState.h
+++ b/lib/APPConvoyLeader/src/DrivingState.h
@@ -141,7 +141,7 @@ private:
     LineStatus             m_lineStatus;  /**< Status of start-/end line detection */
     TrackStatus            m_trackStatus; /**< Status of track which means on track or track lost, etc. */
     uint8_t m_startEndLineDebounce;       /**< Counter used for easys debouncing of the start-/end line detection. */
-    MovAvg<int16_t, uint32_t, 2> m_posMovAvg; /**< The moving average of the position over 2 calling cycles. */
+    MovAvg<int16_t, uint32_t, 2U> m_posMovAvg; /**< The moving average of the position over 2 calling cycles. */
 
     /**
      * Default constructor.

--- a/lib/APPRemoteControl/src/App.h
+++ b/lib/APPRemoteControl/src/App.h
@@ -171,7 +171,7 @@ private:
     /**
      * Moving average filter for proximity sensors.
      */
-    MovAvg<uint8_t, MOVAVG_PROXIMITY_SENSOR_NUM_MEASUREMENTS> m_movAvgProximitySensor;
+    MovAvg<uint8_t, uint16_t, MOVAVG_PROXIMITY_SENSOR_NUM_MEASUREMENTS> m_movAvgProximitySensor;
 
     /**
      * Report the current vehicle data.

--- a/lib/Service/src/MovAvg.hpp
+++ b/lib/Service/src/MovAvg.hpp
@@ -58,9 +58,10 @@
  * It is designed for fix point integers.
  *
  * @tparam T    The data type of the moving average result and input values.
+ * @tparam U    The data type of the moving average sum. Must be able to store the maximum value of T * length.
  * @tparam length The number of values, which are considered in the moving average calculation.
  */
-template<typename T, uint8_t length>
+template<typename T, typename U, uint8_t length>
 class MovAvg
 {
 public:
@@ -149,7 +150,7 @@ private:
     T       m_values[length]; /**< List of values, used for moving average calculation. */
     uint8_t m_wrIdx;          /**< Write index to list of values */
     uint8_t m_written;        /**< The number of written values to the list of values, till length is reached. */
-    T       m_sum;            /**< Sum of all values */
+    U       m_sum;            /**< Sum of all values */
 
     /**
      * Copy construction of an instance.


### PR DESCRIPTION
User can specify the type that holds the sum of the Moving Average to prevent wrapping and overflows.