### PR TITLE
Fixed line sensor calibration in remote app

### DIFF
--- a/lib/APPCalib/src/ErrorState.cpp
+++ b/lib/APPCalib/src/ErrorState.cpp
@@ -71,9 +71,10 @@ LOG_TAG("EState");
 
 void ErrorState::entry()
 {
-    IDisplay& display = Board::getInstance().getDisplay();
-    
-    DifferentialDrive::getInstance().disable();
+    IDisplay&          display   = Board::getInstance().getDisplay();
+    DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
+
+    diffDrive.disable();
 
     display.clear();
     display.print("A: CONT");

--- a/lib/APPCalib/src/MotorSpeedCalibrationState.cpp
+++ b/lib/APPCalib/src/MotorSpeedCalibrationState.cpp
@@ -147,7 +147,10 @@ void MotorSpeedCalibrationState::process(StateMachine& sm)
 
 void MotorSpeedCalibrationState::exit()
 {
-    /* Nothing to do. */
+    DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
+
+    /* Differential drive can now be used. */
+    diffDrive.enable();
 }
 
 /******************************************************************************
@@ -216,9 +219,6 @@ void MotorSpeedCalibrationState::finishCalibration(StateMachine& sm)
      * can now be used.
      */
     diffDrive.setMaxMotorSpeed(maxSpeed);
-
-    /* Differential drive can now be used. */
-    diffDrive.enable();
 
     if (0 == maxSpeed)
     {

--- a/lib/APPConvoyFollower/src/DrivingState.cpp
+++ b/lib/APPConvoyFollower/src/DrivingState.cpp
@@ -77,11 +77,13 @@ void DrivingState::process(StateMachine& sm)
 
 void DrivingState::exit()
 {
+    DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
+
     m_isActive = false;
 
     /* Stop motors. */
-    DifferentialDrive::getInstance().setLinearSpeed(0, 0);
-    DifferentialDrive::getInstance().disable();
+    diffDrive.setLinearSpeed(0, 0);
+    diffDrive.disable();
 }
 
 void DrivingState::setTargetSpeeds(int16_t leftMotor, int16_t rightMotor)

--- a/lib/APPConvoyFollower/src/ErrorState.cpp
+++ b/lib/APPConvoyFollower/src/ErrorState.cpp
@@ -63,8 +63,10 @@
 
 void ErrorState::entry()
 {
-    IDisplay& display = Board::getInstance().getDisplay();
-    DifferentialDrive::getInstance().disable();
+    IDisplay&          display   = Board::getInstance().getDisplay();
+    DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
+
+    diffDrive.disable();
 
     display.clear();
     display.print("Error");

--- a/lib/APPConvoyLeader/src/ErrorState.cpp
+++ b/lib/APPConvoyLeader/src/ErrorState.cpp
@@ -65,8 +65,10 @@
 
 void ErrorState::entry()
 {
-    IDisplay& display = Board::getInstance().getDisplay();
-    DifferentialDrive::getInstance().disable();
+    IDisplay&          display   = Board::getInstance().getDisplay();
+    DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
+
+    diffDrive.disable();
 
     display.clear();
     display.print("Error");

--- a/lib/APPLineFollower/src/ErrorState.cpp
+++ b/lib/APPLineFollower/src/ErrorState.cpp
@@ -71,11 +71,12 @@ LOG_TAG("EState");
 
 void ErrorState::entry()
 {
-    IBoard&   board   = Board::getInstance();
-    IDisplay& display = board.getDisplay();
+    IBoard&            board     = Board::getInstance();
+    IDisplay&          display   = board.getDisplay();
+    DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
 
     /* Stop the motors in any case! */
-    DifferentialDrive::getInstance().disable();
+    diffDrive.disable();
 
     display.clear();
     display.print("A: CONT");

--- a/lib/APPLineFollower/src/MotorSpeedCalibrationState.cpp
+++ b/lib/APPLineFollower/src/MotorSpeedCalibrationState.cpp
@@ -147,7 +147,10 @@ void MotorSpeedCalibrationState::process(StateMachine& sm)
 
 void MotorSpeedCalibrationState::exit()
 {
-    /* Nothing to do. */
+    DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
+
+    /* Differential drive can now be used. */
+    diffDrive.enable();
 }
 
 /******************************************************************************
@@ -216,9 +219,6 @@ void MotorSpeedCalibrationState::finishCalibration(StateMachine& sm)
      * can now be used.
      */
     diffDrive.setMaxMotorSpeed(maxSpeed);
-
-    /* Differential drive can now be used. */
-    diffDrive.enable();
 
     if (0 == maxSpeed)
     {

--- a/lib/APPRemoteControl/src/DrivingState.cpp
+++ b/lib/APPRemoteControl/src/DrivingState.cpp
@@ -77,11 +77,13 @@ void DrivingState::process(StateMachine& sm)
 
 void DrivingState::exit()
 {
+    DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
+    
     m_isActive = false;
 
     /* Stop motors. */
-    DifferentialDrive::getInstance().setLinearSpeed(0, 0);
-    DifferentialDrive::getInstance().disable();
+    diffDrive.setLinearSpeed(0, 0);
+    diffDrive.disable();
 }
 
 void DrivingState::setMotorSpeeds(int16_t leftMotor, int16_t rightMotor)

--- a/lib/APPRemoteControl/src/ErrorState.cpp
+++ b/lib/APPRemoteControl/src/ErrorState.cpp
@@ -63,8 +63,10 @@
 
 void ErrorState::entry()
 {
-    IDisplay& display = Board::getInstance().getDisplay();
-    DifferentialDrive::getInstance().disable();
+    IDisplay&          display   = Board::getInstance().getDisplay();
+    DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
+
+    diffDrive.disable();
 
     display.clear();
     display.print("Error");

--- a/lib/APPRemoteControl/src/LineSensorsCalibrationState.cpp
+++ b/lib/APPRemoteControl/src/LineSensorsCalibrationState.cpp
@@ -87,6 +87,8 @@ void LineSensorsCalibrationState::entry()
     /* Wait some time, before starting the calibration drive. */
     m_phase = PHASE_1_WAIT;
     m_timer.start(WAIT_TIME);
+
+    diffDrive.enable();
 }
 
 void LineSensorsCalibrationState::process(StateMachine& sm)
@@ -137,6 +139,9 @@ void LineSensorsCalibrationState::process(StateMachine& sm)
 
 void LineSensorsCalibrationState::exit()
 {
+    DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
+
+    diffDrive.disable();
     m_timer.stop();
 }
 


### PR DESCRIPTION
In the remote application the differential drive was not enabled in the entry. This caused that the line sensor calibration didn't work. This was fixed, incl. similar handling in all other places too.