### PR TITLE
fix(RemoteControl): initialize VehicleData

### DIFF
--- a/lib/APPConvoyFollower/src/App.cpp
+++ b/lib/APPConvoyFollower/src/App.cpp
@@ -397,7 +397,8 @@ static void App_cmdChannelCallback(const uint8_t* payload, const uint8_t payload
  */
 void App_motorSpeedSetpointsChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
 {
-    (void)userData;
+    UTIL_NOT_USED(userData);
+
     if ((nullptr != payload) && (SPEED_SETPOINT_CHANNEL_DLC == payloadSize))
     {
         const SpeedData* motorSpeedData = reinterpret_cast<const SpeedData*>(payload);

--- a/lib/APPConvoyFollower/src/DrivingState.cpp
+++ b/lib/APPConvoyFollower/src/DrivingState.cpp
@@ -36,6 +36,7 @@
 #include "DrivingState.h"
 #include <StateMachine.h>
 #include <DifferentialDrive.h>
+#include <Util.h>
 
 /******************************************************************************
  * Compiler Switches
@@ -73,7 +74,7 @@ void DrivingState::entry()
 void DrivingState::process(StateMachine& sm)
 {
     /* Nothing to do. */
-    (void)sm;
+    UTIL_NOT_USED(sm);
 }
 
 void DrivingState::exit()

--- a/lib/APPConvoyFollower/src/ErrorState.cpp
+++ b/lib/APPConvoyFollower/src/ErrorState.cpp
@@ -37,6 +37,7 @@
 #include <Board.h>
 #include <StateMachine.h>
 #include <DifferentialDrive.h>
+#include <Util.h>
 
 /******************************************************************************
  * Compiler Switches
@@ -78,7 +79,7 @@ void ErrorState::entry()
 void ErrorState::process(StateMachine& sm)
 {
     /* Nothing to do. */
-    (void)sm;
+    UTIL_NOT_USED(sm);
 }
 
 void ErrorState::exit()

--- a/lib/APPConvoyLeader/src/App.cpp
+++ b/lib/APPConvoyLeader/src/App.cpp
@@ -338,7 +338,8 @@ static void App_cmdChannelCallback(const uint8_t* payload, const uint8_t payload
  */
 void App_motorSpeedSetpointsChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
 {
-    (void)userData;
+    UTIL_NOT_USED(userData);
+
     if ((nullptr != payload) && (SPEED_SETPOINT_CHANNEL_DLC == payloadSize))
     {
         const SpeedData* motorSpeedData = reinterpret_cast<const SpeedData*>(payload);

--- a/lib/APPRemoteControl/src/App.cpp
+++ b/lib/APPRemoteControl/src/App.cpp
@@ -393,7 +393,7 @@ bool App::setupSerialMuxProt()
     m_serialMuxProtChannelIdStatus      = m_smpServer.createChannel(STATUS_CHANNEL_NAME, STATUS_CHANNEL_DLC);
     m_serialMuxProtChannelIdLineSensors = m_smpServer.createChannel(LINE_SENSOR_CHANNEL_NAME, LINE_SENSOR_CHANNEL_DLC);
 
-    /* Channels succesfully created? */
+    /* Channels successfully created? */
     if ((0U != m_serialMuxProtChannelIdCurrentVehicleData) && (0U != m_serialMuxProtChannelIdRemoteCtrlRsp) &&
         (0U != m_serialMuxProtChannelIdStatus) && (0U != m_serialMuxProtChannelIdLineSensors))
     {

--- a/lib/APPRemoteControl/src/App.cpp
+++ b/lib/APPRemoteControl/src/App.cpp
@@ -34,17 +34,17 @@
  * Includes
  *****************************************************************************/
 #include "App.h"
-#include "StartupState.h"
-#include "ErrorState.h"
+#include "Config.h"
 #include "DrivingState.h"
+#include "ErrorState.h"
 #include "LineSensorsCalibrationState.h"
+#include "StartupState.h"
 #include <Board.h>
-#include <Speedometer.h>
 #include <DifferentialDrive.h>
-#include <Odometry.h>
 #include <Logging.h>
+#include <Odometry.h>
+#include <Speedometer.h>
 #include <Util.h>
-#include <Config.h>
 
 #if CONFIG_IMU == CONFIG_ENABLE
 #include <IMU.h>
@@ -409,7 +409,7 @@ void App::sendLineSensorsData() const
     uint8_t         maxLineSensors   = lineSensors.getNumLineSensors();
     const uint16_t* lineSensorValues = lineSensors.getSensorValues();
     uint8_t         lineSensorIdx    = 0U;
-    LineSensorData  payload;
+    LineSensorData  payload          = {};
 
     if (LINE_SENSOR_CHANNEL_DLC == maxLineSensors * sizeof(uint16_t))
     {
@@ -456,9 +456,10 @@ static void App_cmdChannelCallback(const uint8_t* payload, const uint8_t payload
  * @param[in] payloadSize   Size of twice motor speeds
  * @param[in] userData      User data
  */
-void App_motorSpeedSetpointsChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
+static void App_motorSpeedSetpointsChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
 {
-    (void)userData;
+    UTIL_NOT_USED(userData);
+
     if ((nullptr != payload) && (MOTOR_SPEED_SETPOINT_CHANNEL_DLC == payloadSize))
     {
         const MotorSpeed* motorSpeedData  = reinterpret_cast<const MotorSpeed*>(payload);
@@ -475,7 +476,7 @@ void App_motorSpeedSetpointsChannelCallback(const uint8_t* payload, const uint8_
  * @param[in] payloadSize   Size of the Status Flag
  * @param[in] userData      Instance of App class.
  */
-void App_statusChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
+static void App_statusChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
 {
     if ((nullptr != payload) && (STATUS_CHANNEL_DLC == payloadSize) && (nullptr != userData))
     {
@@ -492,9 +493,10 @@ void App_statusChannelCallback(const uint8_t* payload, const uint8_t payloadSize
  * @param[in] payloadSize   Size of the RobotSpeed structure.
  * @param[in] userData      Instance of App class.
  */
-void App_robotSpeedSetpointChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
+static void App_robotSpeedSetpointChannelCallback(const uint8_t* payload, const uint8_t payloadSize, void* userData)
 {
-    (void)userData;
+    UTIL_NOT_USED(userData);
+
     if ((nullptr != payload) && (ROBOT_SPEED_SETPOINT_CHANNEL_DLC == payloadSize))
     {
         const RobotSpeed* robotSpeedData = reinterpret_cast<const RobotSpeed*>(payload);

--- a/lib/APPRemoteControl/src/App.cpp
+++ b/lib/APPRemoteControl/src/App.cpp
@@ -327,17 +327,17 @@ void App::reportVehicleData()
     IProximitySensors& proximitySensors = board.getProximitySensors();
     Odometry&          odometry         = Odometry::getInstance();
     Speedometer&       speedometer      = Speedometer::getInstance();
-    VehicleData        payload;
-    uint32_t           timestamp     = millis();
-    int32_t            xPos          = 0;
-    int32_t            yPos          = 0;
-    uint8_t            maxCounts     = 0U;
-    uint8_t            averageCounts = 0U;
-    uint8_t            leftCounts    = 0U;
-    uint8_t            rightCounts   = 0U;
-    int16_t            leftSpeed     = speedometer.getLinearSpeedLeft();
-    int16_t            rightSpeed    = speedometer.getLinearSpeedRight();
-    int16_t            centerSpeed   = speedometer.getLinearSpeedCenter();
+    VehicleData        payload          = {};
+    uint32_t           timestamp        = millis();
+    int32_t            xPos             = 0;
+    int32_t            yPos             = 0;
+    uint8_t            maxCounts        = 0U;
+    uint8_t            averageCounts    = 0U;
+    uint8_t            leftCounts       = 0U;
+    uint8_t            rightCounts      = 0U;
+    int16_t            leftSpeed        = speedometer.getLinearSpeedLeft();
+    int16_t            rightSpeed       = speedometer.getLinearSpeedRight();
+    int16_t            centerSpeed      = speedometer.getLinearSpeedCenter();
 #if CONFIG_IMU == CONFIG_ENABLE
     IIMU&   imu = board.getIMU();
     IMUData accelerationValues;

--- a/lib/APPRemoteControl/src/DrivingState.cpp
+++ b/lib/APPRemoteControl/src/DrivingState.cpp
@@ -37,6 +37,7 @@
 #include <StateMachine.h>
 #include <DifferentialDrive.h>
 #include <Board.h>
+#include <Util.h>
 
 /******************************************************************************
  * Compiler Switches
@@ -65,7 +66,7 @@
 void DrivingState::entry()
 {
 #if CONFIG_DISPLAY == CONFIG_ENABLE
-    IDisplay&          display   = Board::getInstance().getDisplay();
+    IDisplay& display = Board::getInstance().getDisplay();
 #endif /* CONFIG_DISPLAY == CONFIG_ENABLE */
     DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
 
@@ -82,16 +83,16 @@ void DrivingState::entry()
 void DrivingState::process(StateMachine& sm)
 {
     /* Nothing to do. */
-    (void)sm;
+    UTIL_NOT_USED(sm);
 }
 
 void DrivingState::exit()
 {
 #if CONFIG_DISPLAY == CONFIG_ENABLE
-    IDisplay&          display   = Board::getInstance().getDisplay();
+    IDisplay& display = Board::getInstance().getDisplay();
 #endif /* CONFIG_DISPLAY == CONFIG_ENABLE */
     DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
-    
+
     m_isActive = false;
 
     /* Stop motors. */

--- a/lib/APPRemoteControl/src/ErrorState.cpp
+++ b/lib/APPRemoteControl/src/ErrorState.cpp
@@ -37,6 +37,7 @@
 #include <Board.h>
 #include <StateMachine.h>
 #include <DifferentialDrive.h>
+#include <Util.h>
 
 /******************************************************************************
  * Compiler Switches
@@ -65,7 +66,7 @@
 void ErrorState::entry()
 {
 #if CONFIG_DISPLAY == CONFIG_ENABLE
-    IDisplay&          display   = Board::getInstance().getDisplay();
+    IDisplay& display = Board::getInstance().getDisplay();
 #endif /* CONFIG_DISPLAY == CONFIG_ENABLE */
     DifferentialDrive& diffDrive = DifferentialDrive::getInstance();
 
@@ -82,7 +83,7 @@ void ErrorState::entry()
 void ErrorState::process(StateMachine& sm)
 {
     /* Nothing to do. */
-    (void)sm;
+    UTIL_NOT_USED(sm);
 }
 
 void ErrorState::exit()

--- a/lib/HALConvoyLeaderTarget/Src/NoBuzzer.hpp
+++ b/lib/HALConvoyLeaderTarget/Src/NoBuzzer.hpp
@@ -45,6 +45,7 @@
  *****************************************************************************/
 
 #include <IBuzzer.h>
+#include <Util.h>
 
 /******************************************************************************
  * Macros
@@ -94,36 +95,36 @@ public:
     void playFrequency(uint16_t freq, uint16_t duration, uint8_t volume) final
     {
         /* Nothing to do. */
-        (void)freq;
-        (void)duration;
-        (void)volume;
+        UTIL_NOT_USED(freq);
+        UTIL_NOT_USED(duration);
+        UTIL_NOT_USED(volume);
     }
 
     /**
      * Plays a melody sequence out of RAM.
-     * 
+     *
      * @param[in] sequence Melody sequence in RAM
      */
     void playMelody(const char* sequence) final
     {
         /* Nothing to do. */
-        (void)sequence;
+        UTIL_NOT_USED(sequence);
     }
 
     /**
      * Plays a melody sequence out of program space.
-     * 
+     *
      * @param[in] sequence Melody sequence in program space
      */
     void playMelodyPGM(const char* sequence) final
     {
         /* Nothing to do. */
-        (void)sequence;
+        UTIL_NOT_USED(sequence);
     }
 
     /**
      * Checks whether a note, frequency, or sequence is being played.
-     * 
+     *
      * Note: Avoid calling this method inside a loop without processing the
      * buzzer. On the simulation additional the simulation time needs to run!
      *

--- a/lib/HALSensorFusionTarget/src/NoBuzzer.hpp
+++ b/lib/HALSensorFusionTarget/src/NoBuzzer.hpp
@@ -45,6 +45,7 @@
  *****************************************************************************/
 
 #include <IBuzzer.h>
+#include <Util.h>
 
 /******************************************************************************
  * Macros
@@ -94,36 +95,36 @@ public:
     void playFrequency(uint16_t freq, uint16_t duration, uint8_t volume) final
     {
         /* Nothing to do. */
-        (void)freq;
-        (void)duration;
-        (void)volume;
+        UTIL_NOT_USED(freq);
+        UTIL_NOT_USED(duration);
+        UTIL_NOT_USED(volume);
     }
 
     /**
      * Plays a melody sequence out of RAM.
-     * 
+     *
      * @param[in] sequence Melody sequence in RAM
      */
     void playMelody(const char* sequence) final
     {
         /* Nothing to do. */
-        (void)sequence;
+        UTIL_NOT_USED(sequence);
     }
 
     /**
      * Plays a melody sequence out of program space.
-     * 
+     *
      * @param[in] sequence Melody sequence in program space
      */
     void playMelodyPGM(const char* sequence) final
     {
         /* Nothing to do. */
-        (void)sequence;
+        UTIL_NOT_USED(sequence);
     }
 
     /**
      * Checks whether a note, frequency, or sequence is being played.
-     * 
+     *
      * Note: Avoid calling this method inside a loop without processing the
      * buzzer. On the simulation additional the simulation time needs to run!
      *

--- a/lib/Service/src/Util.h
+++ b/lib/Service/src/Util.h
@@ -49,6 +49,13 @@
 #include <IButton.h>
 #include <RobotConstants.h>
 
+/******************************************************************************
+ * Macros
+ *****************************************************************************/
+
+/** Use it to mark not used function parameters. */
+#define UTIL_NOT_USED(__var) (void)(__var)
+
 /**
  * Utilities
  */


### PR DESCRIPTION
The payload.accelerationX and payload.turnRateZ contain garbage if CONFIG_IMU is not enbabled. Fixed by initializing payload properly.