### PR TITLE
Missing config header added to RemoteControlSim Board.

### DIFF
--- a/lib/HALRemoteControlSim/src/Board.h
+++ b/lib/HALRemoteControlSim/src/Board.h
@@ -44,6 +44,7 @@
  * Includes
  *****************************************************************************/
 #include <stdint.h>
+#include <Config.h>
 #include <IBoard.h>
 #include <ButtonA.h>
 #include <ButtonB.h>


### PR DESCRIPTION
Problem caused by missing header fixed. Because the header defines CONFIG_ENABLE and CONFIG_DISABLE its important to include it, where the pre-processor defines are used. Otherwise the compiler implict uses 0.
