### PR TITLE
Add missing Config.h include to IBoard.h to prevent ODR violation

### DIFF
--- a/lib/APPRemoteControl/src/IBoard.h
+++ b/lib/APPRemoteControl/src/IBoard.h
@@ -45,6 +45,7 @@
  * Includes
  *****************************************************************************/
 #include <stdint.h>
+#include <Config.h>
 #include <IButton.h>
 
 #if CONFIG_BUZZER == CONFIG_ENABLE


### PR DESCRIPTION
Without Config.h, the CONFIG_BUZZER, CONFIG_DISPLAY and CONFIG_IMU macros were undefined when IBoard.h was included before any app header, causing translation units to see different vtable layouts for IBoard depending on include order. This is an ODR violation that manifests as a wrong virtual dispatch offset and a segfault at runtime.